### PR TITLE
Use nbytes from the memory view to identify the length of the buffer.

### DIFF
--- a/libaio/__init__.py
+++ b/libaio/__init__.py
@@ -242,7 +242,7 @@ class AIOBlock(object):
             self._iovec = iovec = (libaio.iovec * buffer_count)(*[
                 libaio.iovec(
                     c_void_p(addressof(c_char.from_buffer(x))),
-                    len(x),
+                    memoryview(x).nbytes,
                 )
                 for x in buffer_list
             ])


### PR DESCRIPTION
Cool library.

Are you still maintaining it?

When using numpy and larger dtypes, the `len` property fails to identify the correct size of the memory view.

Casting to a memoryview seems to fix things. Not sure about python 2.7

I can add a test, but don't know how to run `unittest` locally.