### PR TITLE
libaio: support libaio1t64

### DIFF
--- a/libaio/libaio.py
+++ b/libaio/libaio.py
@@ -150,7 +150,10 @@ del PADDED, PADDEDptr, PADDEDul, PADDEDl
 
 io_callback_t = CFUNCTYPE(None, io_context_t, iocb_p, c_long, c_long)
 
-libaio = CDLL('libaio.so.1')
+try:
+    libaio = CDLL('libaio.so.1t64')
+except FileNotFoundError:
+    libaio = CDLL('libaio.so.1')
 # pylint: disable=unused-argument
 def _raise_on_negative(result, func, arguments):
     if result < 0:


### PR DESCRIPTION
Ubuntu 24.04 (Noble Numbat) replaced the libaio1 package with libaio1t64. As such, libaio.so.1 no longer exists and was replaced with libaio.so.1t64.

Thus, libaio would fail to be imported with an error like:

        libaio = CDLL('libaio.so.1')
                 ^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.12/ctypes/__init__.py", line 379, in __init__
        self._handle = _dlopen(self._name, mode)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    OSError: libaio.so.1: cannot open shared object file: No such file or directory

Fix this by looking for libaio1t64.so.1, and falling back to the older library name