### PR TITLE
Handle OSError in libaio loading

### DIFF
--- a/libaio/libaio.py
+++ b/libaio/libaio.py
@@ -152,7 +152,7 @@ io_callback_t = CFUNCTYPE(None, io_context_t, iocb_p, c_long, c_long)
 
 try:
     libaio = CDLL('libaio.so.1t64')
-except FileNotFoundError:
+except (OSError, FileNotFoundError):
     libaio = CDLL('libaio.so.1')
 # pylint: disable=unused-argument
 def _raise_on_negative(result, func, arguments):


### PR DESCRIPTION
```

In [1]: from ctypes import (
   ...:     CDLL, CFUNCTYPE, POINTER, Union, Structure, memset, sizeof, byref, c_long,
   ...:     c_size_t, c_int64, c_short, c_int, c_uint, c_ulong, c_void_p, c_longlong,
   ...:     cast,
   ...: )

In [2]: CDLL('foo.so')
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
Cell In[2], line 1
----> 1 CDLL('foo.so')

File ~/miniforge3/envs/dev/lib/python3.12/ctypes/__init__.py:379, in CDLL.__init__(self, name, mode, handle, use_errno, use_last_error, winmode)
    376 self._FuncPtr = _FuncPtr
    378 if handle is None:
--> 379     self._handle = _dlopen(self._name, mode)
    380 else:
    381     self._handle = handle

OSError: foo.so: cannot open shared object file: No such file or directory
```